### PR TITLE
feat: rename module to initium-cli

### DIFF
--- a/.github/workflows/onbranch.yaml
+++ b/.github/workflows/onbranch.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: build and deploy on pr
         run: go run main.go onbranch --stop-on-push
         env:
-          KKA_APP_NAME: k8s-kurated-addons-cli
-          KKA_REGISTRY_USER: ${{ github.actor }}
-          KKA_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          INITIUM_APP_NAME: initium-cli
+          INITIUM_REGISTRY_USER: ${{ github.actor }}
+          INITIUM_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/onmain.yaml
+++ b/.github/workflows/onmain.yaml
@@ -19,6 +19,6 @@ jobs:
       - name: build and deploy on main
         run: go run main.go onmain --stop-on-push
         env:
-          KKA_APP_NAME: k8s-kurated-addons-cli
-          KKA_REGISTRY_USER: ${{ github.actor }}
-          KKA_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          INITIUM_APP_NAME: initium-cli
+          INITIUM_REGISTRY_USER: ${{ github.actor }}
+          INITIUM_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea/
 .vscode/
 .env
-Dockerfile.kka
+Dockerfile.initium
 *.init_test*
-kka_onmain.yaml
-kka_onbranch.yaml
+initium_onmain.yaml
+initium_onbranch.yaml

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help: ## help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build: ## build cli app as binary
-	go build -o bin/kka-cli
+	go build -o bin/initium
 
 project_build: ## build a project using the cli
 	@go run main.go build
@@ -17,7 +17,7 @@ project_push: ## push a project to an registry
 	@go run main.go push
 
 static: ## build static
-	CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o bin/kka-cli
+	CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o bin/initium
 
 install: ## install dependencies
 	go install

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ You will be able to run the executable from
 These are the environment variables that you have to set in order to use the onmain, onbranch commands from your local environment
 
 ```
-export KKA_REGISTRY_PASSWORD="<github_pat>"
-export KKA_REGISTRY_USER="<github_user>"
+export INITIUM_REGISTRY_PASSWORD="<github_pat>"
+export INITIUM_REGISTRY_USER="<github_user>"
 ```
 
 and
 
 ```
-export KKA_CLUSTER_ENDPOINT=$(kubectl config view -o jsonpath='{.clusters[?(@.name == "kind-k8s-kurated-addons")].cluster.server}')
-export KKA_CLUSTER_TOKEN=$(kubectl get secrets initium-cli-token -o jsonpath="{.data.token}" | base64 -d)
-export KKA_CLUSTER_CA_CERT=$(kubectl get secrets initium-cli-token -o jsonpath="{.data.ca\.crt}" | base64 -d)
+export INITIUM_CLUSTER_ENDPOINT=$(kubectl config view -o jsonpath='{.clusters[?(@.name == "kind-k8s-kurated-addons")].cluster.server}')
+export INITIUM_CLUSTER_TOKEN=$(kubectl get secrets initium-cli-token -o jsonpath="{.data.token}" | base64 -d)
+export INITIUM_CLUSTER_CA_CERT=$(kubectl get secrets initium-cli-token -o jsonpath="{.data.ca\.crt}" | base64 -d)
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# k8s Kurated Addons Cli
+# Initium project CLI
 
-This project is intended for building an executable file to run on various CI/CD platforms in order to get a project deployed to a containerised environment
+A single static binary that can run on any CI to build your code and deploy it in a single step.
+
+All with a nice development workflow in mind like ephemeral environment for your PRs.
 
 ### Pre-requisites
 
@@ -19,7 +21,7 @@ This project is intended for building an executable file to run on various CI/CD
 ### Run from code
 
 1. Run `go run main.go --project-directory example build`
-2. Run `docker run ghcr.io/nearform/k8s-kurated-addons-cli:latest`
+2. Run `docker run ghcr.io/nearform/initium-cli:latest`
 3. You should see the `KKA-CLI from NearForm` output in your console
 4. Remove the image `docker image rmi -f ghcr.io/nearform/k8s-kurated-addons-cli:latest`
 
@@ -34,7 +36,7 @@ make build
 You will be able to run the executable from 
 
 ```bash
-./bin/kka-cli
+./bin/initium
 ```
 
 ### Setup local environment
@@ -50,6 +52,6 @@ and
 
 ```
 export KKA_CLUSTER_ENDPOINT=$(kubectl config view -o jsonpath='{.clusters[?(@.name == "kind-k8s-kurated-addons")].cluster.server}')
-export KKA_CLUSTER_TOKEN=$(kubectl get secrets kka-cli-token -o jsonpath="{.data.token}" | base64 -d)
-export KKA_CLUSTER_CA_CERT=$(kubectl get secrets kka-cli-token -o jsonpath="{.data.ca\.crt}" | base64 -d)
+export KKA_CLUSTER_TOKEN=$(kubectl get secrets initium-cli-token -o jsonpath="{.data.token}" | base64 -d)
+export KKA_CLUSTER_CA_CERT=$(kubectl get secrets initium-cli-token -o jsonpath="{.data.ca\.crt}" | base64 -d)
 ```

--- a/assets/github/onbranch.tmpl
+++ b/assets/github/onbranch.tmpl
@@ -1,4 +1,4 @@
-# This file is generate by https://github.com/nearform/k8s-kurated-addons-cli
+# This file is generate by https://github.com/nearform/initium-cli
 name: Deploy on PR
 
 on:

--- a/assets/github/onbranch.tmpl
+++ b/assets/github/onbranch.tmpl
@@ -20,11 +20,11 @@ jobs:
         with:
           args: onbranch --clean
         env:
-          KKA_REGISTRY_USER: {{ `${{ github.actor }}` }}
-          KKA_REGISTRY_PASSWORD: {{ `${{ secrets.GITHUB_TOKEN }}` }}
-          KKA_CLUSTER_ENDPOINT: {{ `${{ secrets.CLUSTER_ENDPOINT }}` }}
-          KKA_CLUSTER_TOKEN: {{ `${{ secrets.CLUSTER_TOKEN }}` }}
-          KKA_CLUSTER_CA_CERT: {{ `${{ secrets.CLUSTER_CA_CERT }}` }}
+          INITIUM_REGISTRY_USER: {{ `${{ github.actor }}` }}
+          INITIUM_REGISTRY_PASSWORD: {{ `${{ secrets.GITHUB_TOKEN }}` }}
+          INITIUM_CLUSTER_ENDPOINT: {{ `${{ secrets.CLUSTER_ENDPOINT }}` }}
+          INITIUM_CLUSTER_TOKEN: {{ `${{ secrets.CLUSTER_TOKEN }}` }}
+          INITIUM_CLUSTER_CA_CERT: {{ `${{ secrets.CLUSTER_CA_CERT }}` }}
 
       - name: build and deploy application
         if: github.event.action != 'closed'
@@ -32,8 +32,8 @@ jobs:
         with:
           args: onbranch
         env:
-          KKA_REGISTRY_USER: {{ `${{ github.actor }}` }}
-          KKA_REGISTRY_PASSWORD: {{ `${{ secrets.GITHUB_TOKEN }}` }}
-          KKA_CLUSTER_ENDPOINT: {{ `${{ secrets.CLUSTER_ENDPOINT }}` }}
-          KKA_CLUSTER_TOKEN: {{ `${{ secrets.CLUSTER_TOKEN }}` }}
-          KKA_CLUSTER_CA_CERT: {{ `${{ secrets.CLUSTER_CA_CERT }}` }}
+          INITIUM_REGISTRY_USER: {{ `${{ github.actor }}` }}
+          INITIUM_REGISTRY_PASSWORD: {{ `${{ secrets.GITHUB_TOKEN }}` }}
+          INITIUM_CLUSTER_ENDPOINT: {{ `${{ secrets.CLUSTER_ENDPOINT }}` }}
+          INITIUM_CLUSTER_TOKEN: {{ `${{ secrets.CLUSTER_TOKEN }}` }}
+          INITIUM_CLUSTER_CA_CERT: {{ `${{ secrets.CLUSTER_CA_CERT }}` }}

--- a/assets/github/onmain.tmpl
+++ b/assets/github/onmain.tmpl
@@ -17,8 +17,8 @@ jobs:
         with:
           args: onmain
         env:
-          KKA_REGISTRY_USER: {{ `${{ github.actor }}` }}
-          KKA_REGISTRY_PASSWORD: {{ `${{ secrets.GITHUB_TOKEN }}` }}
-          KKA_CLUSTER_ENDPOINT: {{ `${{ secrets.CLUSTER_ENDPOINT }}` }}
-          KKA_CLUSTER_TOKEN: {{ `${{ secrets.CLUSTER_TOKEN }}` }}
-          KKA_CLUSTER_CA_CERT: {{ `${{ secrets.CLUSTER_CA_CERT }}` }}
+          INITIUM_REGISTRY_USER: {{ `${{ github.actor }}` }}
+          INITIUM_REGISTRY_PASSWORD: {{ `${{ secrets.GITHUB_TOKEN }}` }}
+          INITIUM_CLUSTER_ENDPOINT: {{ `${{ secrets.CLUSTER_ENDPOINT }}` }}
+          INITIUM_CLUSTER_TOKEN: {{ `${{ secrets.CLUSTER_TOKEN }}` }}
+          INITIUM_CLUSTER_CA_CERT: {{ `${{ secrets.CLUSTER_CA_CERT }}` }}

--- a/assets/github/onmain.tmpl
+++ b/assets/github/onmain.tmpl
@@ -1,4 +1,4 @@
-# This file is generate by https://github.com/nearform/k8s-kurated-addons-cli
+# This file is generate by https://github.com/nearform/initium-cli
 name: Deploy on {{ .DefaultBranch }}
 
 on: 

--- a/assets/k8s/serviceAccount/cluster-role.yaml
+++ b/assets/k8s/serviceAccount/cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kka-cli
+  name: initium-cli
 rules:
   - apiGroups:
       - ''

--- a/assets/k8s/serviceAccount/role-binding.yaml
+++ b/assets/k8s/serviceAccount/role-binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kka-cli
+  name: initium-cli
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kka-cli
+  name: initium-cli
 subjects:
   - kind: ServiceAccount
-    name: kka-cli-bot
+    name: initium-cli-sa
     namespace: default

--- a/assets/k8s/serviceAccount/service-account.yaml
+++ b/assets/k8s/serviceAccount/service-account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kka-cli-bot
+  name: initium-cli-sa

--- a/assets/k8s/serviceAccount/token.yaml
+++ b/assets/k8s/serviceAccount/token.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/service-account-token
 metadata:
-  name: kka-cli-token
+  name: initium-cli-token
   annotations:
-    kubernetes.io/service-account.name: "kka-cli-bot"
+    kubernetes.io/service-account.name: "initium-cli-sa"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nearform/k8s-kurated-addons-cli
+module github.com/nearform/initium-cli
 
 go 1.20
 
@@ -7,6 +7,7 @@ require (
 	github.com/docker/docker v23.0.1+incompatible
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587
+	github.com/nearform/k8s-kurated-addons-cli v0.0.0-20230808135356-7f588534fbf2
 	github.com/urfave/cli/v2 v2.25.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.1
@@ -97,7 +98,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gotest.tools/v3 v3.4.0 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a // indirect
 	knative.dev/networking v0.0.0-20230419144338-e5d04e805e50 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/docker/docker v23.0.1+incompatible
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587
-	github.com/nearform/k8s-kurated-addons-cli v0.0.0-20230808135356-7f588534fbf2
 	github.com/urfave/cli/v2 v2.25.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.1

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,6 @@ github.com/muesli/termenv v0.15.1 h1:UzuTb/+hhlBugQz28rpzey4ZuKcZ03MeKsoG7IJZIxs
 github.com/muesli/termenv v0.15.1/go.mod h1:HeAQPTzpfs016yGtA4g00CsdYnVLJvxsS4ANqrZs2sQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nearform/k8s-kurated-addons-cli v0.0.0-20230808135356-7f588534fbf2 h1:5d3YwJMCB9Bf01LKhH04GYP7rw5AJ2gsh/TXsv8W33A=
-github.com/nearform/k8s-kurated-addons-cli v0.0.0-20230808135356-7f588534fbf2/go.mod h1:UNsqNiAo1u35/nKuVtjjTZctXKUZdg4RfXu7VA1QxOQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/muesli/termenv v0.15.1 h1:UzuTb/+hhlBugQz28rpzey4ZuKcZ03MeKsoG7IJZIxs
 github.com/muesli/termenv v0.15.1/go.mod h1:HeAQPTzpfs016yGtA4g00CsdYnVLJvxsS4ANqrZs2sQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/nearform/k8s-kurated-addons-cli v0.0.0-20230808135356-7f588534fbf2 h1:5d3YwJMCB9Bf01LKhH04GYP7rw5AJ2gsh/TXsv8W33A=
+github.com/nearform/k8s-kurated-addons-cli v0.0.0-20230808135356-7f588534fbf2/go.mod h1:UNsqNiAo1u35/nKuVtjjTZctXKUZdg4RfXu7VA1QxOQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
@@ -361,7 +363,6 @@ golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -406,7 +407,6 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
@@ -472,7 +472,6 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
-gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.27.1 h1:Z6zUGQ1Vd10tJ+gHcNNNgkV5emCyW+v2XTmn+CLjSd0=

--- a/go.sum
+++ b/go.sum
@@ -469,7 +469,7 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.27.1 h1:Z6zUGQ1Vd10tJ+gHcNNNgkV5emCyW+v2XTmn+CLjSd0=

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	cli := cli.CLI{
 		Resources: resources,
 		Logger: log.NewWithOptions(os.Stderr, log.Options{
-			Level:           log.ParseLevel(os.Getenv("KKA_LOG_LEVEL")),
+			Level:           log.ParseLevel(os.Getenv("INITIUM_LOG_LEVEL")),
 			ReportCaller:    true,
 			ReportTimestamp: true,
 		}),

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/log"
-	"github.com/nearform/k8s-kurated-addons-cli/src/cli"
+	"github.com/nearform/initium-cli/src/cli"
 )
 
 //go:embed assets

--- a/src/cli/build.go
+++ b/src/cli/build.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"path"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/logger"
+	"github.com/nearform/initium-cli/src/utils/logger"
 	"github.com/urfave/cli/v2"
 )
 

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -101,8 +101,8 @@ func (c *CLI) getProject(cCtx *cli.Context) (*project.Project, error) {
 
 func (c CLI) Run(args []string) error {
 	app := &cli.App{
-		Name:  "k8s kurated addons",
-		Usage: "kka-cli",
+		Name:  "initium",
+		Usage: "CLI of the Initium project",
 		Flags: c.CommandFlags(App),
 		Commands: []*cli.Command{
 			c.BuildCMD(),

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -7,13 +7,13 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/project"
+	"github.com/nearform/initium-cli/src/services/project"
 	"k8s.io/utils/strings/slices"
 
 	"github.com/charmbracelet/log"
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/docker"
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/defaults"
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/logger"
+	"github.com/nearform/initium-cli/src/services/docker"
+	"github.com/nearform/initium-cli/src/utils/defaults"
+	"github.com/nearform/initium-cli/src/utils/logger"
 	"github.com/urfave/cli/v2"
 )
 

--- a/src/cli/delete.go
+++ b/src/cli/delete.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	knative "github.com/nearform/k8s-kurated-addons-cli/src/services/k8s"
+	knative "github.com/nearform/initium-cli/src/services/k8s"
 	"github.com/urfave/cli/v2"
 )
 

--- a/src/cli/deploy.go
+++ b/src/cli/deploy.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	knative "github.com/nearform/k8s-kurated-addons-cli/src/services/k8s"
+	knative "github.com/nearform/initium-cli/src/services/k8s"
 	"github.com/urfave/cli/v2"
 )
 

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/git"
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/defaults"
+	"github.com/nearform/initium-cli/src/services/git"
+	"github.com/nearform/initium-cli/src/utils/defaults"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v2"
 	"k8s.io/utils/strings/slices"

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -59,32 +59,32 @@ func init() {
 		Build: []cli.Flag{
 			&cli.StringFlag{
 				Name:     runtimeVersionFlag,
-				EnvVars:  []string{"KKA_RUNTIME_VERSION"},
+				EnvVars:  []string{"INITIUM_RUNTIME_VERSION"},
 				Category: "build",
 			},
 		},
 		Kubernetes: []cli.Flag{
 			&cli.StringFlag{
 				Name:     endpointFlag,
-				EnvVars:  []string{"KKA_CLUSTER_ENDPOINT"},
+				EnvVars:  []string{"INITIUM_CLUSTER_ENDPOINT"},
 				Required: true,
 				Category: "deploy",
 			},
 			&cli.StringFlag{
 				Name:     tokenFlag,
-				EnvVars:  []string{"KKA_CLUSTER_TOKEN"},
+				EnvVars:  []string{"INITIUM_CLUSTER_TOKEN"},
 				Required: true,
 				Category: "deploy",
 			},
 			&cli.StringFlag{
 				Name:     caCRTFlag,
-				EnvVars:  []string{"KKA_CLUSTER_CA_CERT"},
+				EnvVars:  []string{"INITIUM_CLUSTER_CA_CERT"},
 				Required: true,
 				Category: "deploy",
 			},
 			&cli.StringFlag{
 				Name:     namespaceFlag,
-				EnvVars:  []string{"KKA_NAMESPACE"},
+				EnvVars:  []string{"INITIUM_NAMESPACE"},
 				Required: true,
 				Category: "deploy",
 			},
@@ -92,13 +92,13 @@ func init() {
 		Registry: []cli.Flag{
 			&cli.StringFlag{
 				Name:     registryUserFlag,
-				EnvVars:  []string{"KKA_REGISTRY_USER"},
+				EnvVars:  []string{"INITIUM_REGISTRY_USER"},
 				Required: true,
 				Category: "registry",
 			},
 			&cli.StringFlag{
 				Name:     registryPasswordFlag,
-				EnvVars:  []string{"KKA_REGISTRY_PASSWORD"},
+				EnvVars:  []string{"INITIUM_REGISTRY_PASSWORD"},
 				Required: true,
 				Category: "registry",
 			},
@@ -122,37 +122,37 @@ func init() {
 				Name:     appNameFlag,
 				Usage:    "The name of the app",
 				Required: true,
-				EnvVars:  []string{"KKA_APP_NAME"},
+				EnvVars:  []string{"INITIUM_APP_NAME"},
 			},
 			&cli.StringFlag{
 				Name:    appVersionFlag,
 				Usage:   "The version of your application",
 				Value:   defaults.AppVersion,
-				EnvVars: []string{"KKA_VERSION"},
+				EnvVars: []string{"INITIUM_VERSION"},
 			},
 			&cli.StringFlag{
 				Name:    projectDirectoryFlag,
 				Usage:   "The directory in which your Dockerfile lives",
 				Value:   defaults.ProjectDirectory,
-				EnvVars: []string{"KKA_PROJECT_DIRECTORY"},
+				EnvVars: []string{"INITIUM_PROJECT_DIRECTORY"},
 			},
 			&cli.StringFlag{
 				Name:     repoNameFlag,
 				Usage:    "The base address of the container repository",
 				Value:    registry,
 				Required: registry == "",
-				EnvVars:  []string{"KKA_REPO_NAME"},
+				EnvVars:  []string{"INITIUM_REPO_NAME"},
 			},
 			&cli.StringFlag{
 				Name:    dockerFileNameFlag,
 				Usage:   "The name of the Dockerfile",
-				EnvVars: []string{"KKA_DOCKERFILE_NAME"},
+				EnvVars: []string{"INITIUM_DOCKERFILE_NAME"},
 			},
 			&cli.StringFlag{
 				Name:    configFileFlag,
 				Usage:   "read parameters from config",
 				Value:   defaults.ConfigFile,
-				EnvVars: []string{"KKA_CONFIG_FILE"},
+				EnvVars: []string{"INITIUM_CONFIG_FILE"},
 			},
 		},
 	}

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -194,7 +194,6 @@ func (c CLI) checkRequiredFlags(ctx *cli.Context, ignoredFlags []string) error {
 func (c CLI) loadFlagsFromConfig(ctx *cli.Context) error {
 	config := make(map[interface{}]interface{})
 	cfgFile := ctx.String(configFileFlag)
-
 	//if the default config file doesn't exist we can ignore the rest and return nil
 	_, err := os.Stat(cfgFile)
 	if err != nil && errors.Is(err, os.ErrNotExist) && cfgFile == defaults.ConfigFile {

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -8,8 +8,8 @@ import (
 	"github.com/charmbracelet/log"
 	"k8s.io/utils/strings/slices"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/k8s"
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/project"
+	"github.com/nearform/initium-cli/src/services/k8s"
+	"github.com/nearform/initium-cli/src/services/project"
 	"github.com/urfave/cli/v2"
 )
 

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -33,13 +33,13 @@ func TestInitConfig(t *testing.T) {
 	cli := CLI{
 		Writer: new(bytes.Buffer),
 		Logger: log.NewWithOptions(os.Stderr, log.Options{
-			Level:           log.ParseLevel(os.Getenv("KKA_LOG_LEVEL")),
+			Level:           log.ParseLevel(os.Getenv("INITIUM_LOG_LEVEL")),
 			ReportCaller:    true,
 			ReportTimestamp: true,
 		}),
 	}
 
-	os.Setenv("KKA_REPO_NAME", "ghcr.io/nearform")
+	os.Setenv("INITIUM_REPO_NAME", "ghcr.io/nearform")
 
 	// Config file is read correctly
 
@@ -62,7 +62,7 @@ func TestInitConfig(t *testing.T) {
 	compareConfig(t, "FromFile", cli.Writer)
 
 	// Environment Variable wins over config
-	os.Setenv("KKA_APP_NAME", "FromEnv")
+	os.Setenv("INITIUM_APP_NAME", "FromEnv")
 	cli.Writer = new(bytes.Buffer)
 	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "init", "config"}); err != nil {
 		t.Error(err)

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -56,7 +56,7 @@ func TestInitConfig(t *testing.T) {
 	}
 
 	cli.Writer = new(bytes.Buffer)
-	if err = cli.Run([]string{"kka", fmt.Sprintf("--config-file=%s", f.Name()), "init", "config"}); err != nil {
+	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "init", "config"}); err != nil {
 		t.Error(err)
 	}
 	compareConfig(t, "FromFile", cli.Writer)
@@ -64,14 +64,14 @@ func TestInitConfig(t *testing.T) {
 	// Environment Variable wins over config
 	os.Setenv("KKA_APP_NAME", "FromEnv")
 	cli.Writer = new(bytes.Buffer)
-	if err = cli.Run([]string{"kka", fmt.Sprintf("--config-file=%s", f.Name()), "init", "config"}); err != nil {
+	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "init", "config"}); err != nil {
 		t.Error(err)
 	}
 	compareConfig(t, "FromEnv", cli.Writer)
 
 	// Command line argument wins over config and Environment variable
 	cli.Writer = new(bytes.Buffer)
-	if err = cli.Run([]string{"kka", fmt.Sprintf("--config-file=%s", f.Name()), "--app-name=FromParam", "init", "config"}); err != nil {
+	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "--app-name=FromParam", "init", "config"}); err != nil {
 		t.Error(err)
 	}
 	compareConfig(t, "FromParam", cli.Writer)

--- a/src/cli/onbranch.go
+++ b/src/cli/onbranch.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	git "github.com/go-git/go-git/v5"
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils"
+	"github.com/nearform/initium-cli/src/utils"
 	"github.com/urfave/cli/v2"
 )
 

--- a/src/cli/onmain.go
+++ b/src/cli/onmain.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/defaults"
+	"github.com/nearform/initium-cli/src/utils/defaults"
 	"github.com/urfave/cli/v2"
 )
 

--- a/src/services/docker/docker.go
+++ b/src/services/docker/docker.go
@@ -14,10 +14,10 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/project"
+	"github.com/nearform/initium-cli/src/services/project"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/defaults"
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/logger"
+	"github.com/nearform/initium-cli/src/utils/defaults"
+	"github.com/nearform/initium-cli/src/utils/logger"
 )
 
 type DockerService struct {

--- a/src/services/docker/docker_test.go
+++ b/src/services/docker/docker_test.go
@@ -3,8 +3,8 @@ package docker
 import (
 	"testing"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/project"
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/defaults"
+	"github.com/nearform/initium-cli/src/services/project"
+	"github.com/nearform/initium-cli/src/utils/defaults"
 )
 
 func TestLocalTag(t *testing.T) {

--- a/src/services/k8s/knative.go
+++ b/src/services/k8s/knative.go
@@ -8,10 +8,10 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/docker"
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/project"
+	"github.com/nearform/initium-cli/src/services/docker"
+	"github.com/nearform/initium-cli/src/services/project"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/logger"
+	"github.com/nearform/initium-cli/src/utils/logger"
 
 	corev1 "k8s.io/api/core/v1"
 	apimachineryErrors "k8s.io/apimachinery/pkg/api/errors"

--- a/src/services/k8s/knative_test.go
+++ b/src/services/k8s/knative_test.go
@@ -7,8 +7,8 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/docker"
-	"github.com/nearform/k8s-kurated-addons-cli/src/services/project"
+	"github.com/nearform/initium-cli/src/services/docker"
+	"github.com/nearform/initium-cli/src/services/project"
 )
 
 var root = "../../../"

--- a/src/services/project/project.go
+++ b/src/services/project/project.go
@@ -101,7 +101,7 @@ func ProjectInit(options InitOptions, resources fs.FS) ([]string, error) {
 			return returnData, err
 		}
 
-		destinationFile := path.Join(options.DestinationFolder, fmt.Sprintf("kka_%s.yaml", tmpl))
+		destinationFile := path.Join(options.DestinationFolder, fmt.Sprintf("initium_%s.yaml", tmpl))
 
 		if err := os.MkdirAll(options.DestinationFolder, os.ModePerm); err != nil {
 			return returnData, fmt.Errorf("error: %v", err)

--- a/src/services/project/project.go
+++ b/src/services/project/project.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"text/template"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/defaults"
+	"github.com/nearform/initium-cli/src/utils/defaults"
 )
 
 type ProjectType string

--- a/src/services/project/project_test.go
+++ b/src/services/project/project_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nearform/k8s-kurated-addons-cli/src/utils/defaults"
+	"github.com/nearform/initium-cli/src/utils/defaults"
 )
 
 var projects = map[ProjectType]map[string]string{

--- a/src/utils/defaults/defaults.go
+++ b/src/utils/defaults/defaults.go
@@ -5,9 +5,9 @@ const (
 	RepoName            string = "ghcr.io/nearform"
 	GithubActionFolder  string = ".github/workflows"
 	GithubDefaultBranch string = "main"
-	ConfigFile          string = ".kka"
+	ConfigFile          string = ".initium.yaml"
 	AppVersion          string = "latest"
-	GeneratedDockerFile string = "Dockerfile.kka"
+	GeneratedDockerFile string = "Dockerfile.initium"
 )
 
 // renovate: datasource=docker depName=node

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -11,7 +11,7 @@ var alphanumericRegex = regexp.MustCompile(`[a-z0-9]`)
 // and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
 func EncodeRFC1123(label string) string {
-	validLabel := "kka-"
+	validLabel := "initium-"
 
 	for _, r := range strings.ToLower(label) {
 		if alphanumericRegex.MatchString(string(r)) {


### PR DESCRIPTION
This updates the module to be `initium-cli`, the binary generated will be called `initium` and the environment variables prefix will be `INITIUM`

The next step after merging this PR is to rename the repository itself to `initium-cli`. 